### PR TITLE
Fixed typo in the registration of the oqs default algorithm

### DIFF
--- a/kex.h
+++ b/kex.h
@@ -69,7 +69,7 @@
 
 #if defined(WITH_OQS) && defined(WITH_PQ_KEX)
 
-#define KEX_OQSDEFAULT_SHA384 PQ_OQS_KEX_SUFFIX("oqsdefault")
+#define KEX_OQSDEFAULT_SHA384 PQ_OQS_KEX_SUFFIX("oqsdefault-sha384")
 #define KEX_FRODO_640_AES_SHA384 PQ_OQS_KEX_SUFFIX("frodo-640-aes-sha384")
 #define KEX_FRODO_976_AES_SHA384 PQ_OQS_KEX_SUFFIX("frodo-976-aes-sha384")
 #define KEX_SIKE_503_SHA384	PQ_OQS_KEX_SUFFIX("sike-503-sha384")


### PR DESCRIPTION
Fixes issue reported by @crockeea in #9 
`$make tests` returns no errors (Ubuntu platform).