### PR TITLE
Fixed macro ifdefs to enable building without openssl.

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -170,11 +170,11 @@ static int
 init_hybrid_kex(HYBRID_KEX_CTX **hybrid_kex_ctx, const struct kexalg *kexalg) {
 
 	switch (kexalg->type) {
-#ifdef WITH_OQS
+#if defined(OPENSSL_HAS_ECC) && defined(WITH_OQS)
 		case KEX_HY_ECDH_OQS:
 			return hybrid_ecdh_oqs_init(hybrid_kex_ctx, kexalg->name,
 				kexalg->ec_nid);
-#endif /* WITH_OQS */
+#endif /* OPENSSL_HAS_ECC && WITH_OQS */
 		default:
 			return 0;
 	}

--- a/kexhy.h
+++ b/kexhy.h
@@ -114,7 +114,7 @@ typedef int (*hybrid_func_cb)(struct ssh *);
 static inline hybrid_func_cb
 get_hybrid_ecdh_oqs_client_cb() {
 
-#if defined(WITH_OQS) && defined(WITH_HYBRID_KEX)
+#if defined(OPENSSL_HAS_ECC) && defined(WITH_OQS) && defined(WITH_HYBRID_KEX)
     return hybrid_ecdh_oqs_client;
 #else
     return NULL;
@@ -124,7 +124,7 @@ get_hybrid_ecdh_oqs_client_cb() {
 static inline hybrid_func_cb
 get_hybrid_ecdh_oqs_server_cb() {
 
-#if defined(WITH_OQS) && defined(WITH_HYBRID_KEX)
+#if defined(OPENSSL_HAS_ECC) && defined(WITH_OQS) && defined(WITH_HYBRID_KEX)
     return hybrid_ecdh_oqs_server;
 #else
     return NULL;


### PR DESCRIPTION
The OQS fork was not building when compiling the project without openssl:
`./configure --enable-pq-kex --enable-hybrid-kex --without-openssl --prefix=<path_to_openssh> --sysconfdir=<path_to_openssh> --with-liboqs-dir=<path_to_oqs>`

I added some ifdef macros in the OQS-related hybrid code that also needed openssl.