### PR TITLE
Always force use of correct ECC curve for ECDSA hybrids that specify a particular one; fixes #73

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -234,9 +234,11 @@ type_bits_valid(int type, const char *name, u_int32_t *bitsp)
 	   * by different types (unlike ECDSA which uses one key type and a 2nd
 	   * 'nid' value to identify the curve. We need this special processing
 	   * for ECDSA hybrid of levels 3+ to avoid defaulting to P256 when
-	   * name is NULL (like when called from do_gen_all_hostkeys).
+	   * name is NULL (like when called from do_gen_all_hostkeys), or when
+           * the short name for one of these particular schemes is used, as is
+           * the norm for the -t argument to ssh-keygen.
 	   */
-	if (name == NULL && IS_ECDSA_HYBRID(type)) {
+	if (IS_ECDSA_HYBRID(type)) {
 		switch (type) {
 ///// OQS_TEMPLATE_FRAGMENT_SET_BITS_START
 		case KEY_P384_RAINBOW_IIIC_CLASSIC:


### PR DESCRIPTION
This change coerces the curve bit length in all cases in ssh-keygen, even when a scheme name is provided.

Calling ssh-keygen with the short name version of an ECDSA hybrid that calls for a particular curve that isn't P-256 (p384-rainbowiiicclassic and p521-rainbowvcclassic at present) would actually cause a key pair on P-256 to be generated as the classical part. Using the short name is very common.

This key would then not be recognized when loaded, because the EC nids would not match with the keytypes table.