### PR TITLE
Fix typo in generate.yml

### DIFF
--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -522,7 +522,7 @@ kems:
         name: "SIKE_P751"
         oqs_meth: "OQS_KEM_alg_sike_p751"
       -
-        NAME: "SIKE_P434_COMPRESSED"
+        name: "SIKE_P434_COMPRESSED"
         oqs_meth: "OQS_KEM_alg_sike_p434_compressed"
       -
         name: "SIKE_P503_COMPRESSED"


### PR DESCRIPTION
This typo prevents SIKE p434 compressed from being generated

Closes #75 