### PR TITLE
Increase MAX_PROP to 140

### DIFF
--- a/match.c
+++ b/match.c
@@ -251,7 +251,7 @@ match_user(const char *user, const char *host, const char *ipaddr,
  * Returns first item from client-list that is also supported by server-list,
  * caller must free the returned string.
  */
-#define	MAX_PROP	40
+#define	MAX_PROP	140
 #define	SEP	","
 char *
 match_list(const char *client, const char *server, u_int *next)


### PR DESCRIPTION
MAX_PROP limits the number of kex algorithm proposals considered from the server by the client. With the liboqs options exceeding this number, an unfortunate ordering in the server's proposal can cause OpenSSH to pick the wrong kex in violation of the RFC.

This change increases MAX_PROP to 140, which will allow for a longer list including all liboqs options.