### PR TITLE
Revert "CI update to Ubuntu 20"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
     default: false
 
 jobs:
-  ubuntu_build:
+  ubuntu_bionic:
     description: A template for running BoringSSL tests on x64 Ubuntu Bionic Docker VMs
     parameters:
       WITH_OPENSSL:
@@ -16,7 +16,7 @@ jobs:
         type: boolean
         default: true
     docker:
-      - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+      - image: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
         auth:
           username: $DOCKER_LOGIN
           password: $DOCKER_PASSWORD
@@ -45,10 +45,10 @@ workflows:
   version: 2.1
   build:
     jobs:
-      - ubuntu_build:
+      - ubuntu_bionic:
           name: with-openssl
           context: openquantumsafe
-      - ubuntu_build:
+      - ubuntu_bionic:
           name: without-openssl
           context: openquantumsafe
           WITH_OPENSSL: false


### PR DESCRIPTION
The readme in `ops-test` specifies that it requires Ubuntu 18.04. Why that is, I don't know -- but I can confirm it is working on bionic.

Reverts open-quantum-safe/openssh#86