### PR TITLE
CCI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/uwl8qgs60mqh5x9j?svg=true)](https://ci.appveyor.com/project/dstebila/openssh/branch/OQS-v8),
-[![CircleCI](https://circleci.com/gh/open-quantum-safe/openssh/tree/OQS-master.svg?style=svg)](https://circleci.com/gh/open-quantum-safe/openssh/tree/OQS-master)
+[![CircleCI](https://circleci.com/gh/open-quantum-safe/openssh/tree/OQS-v8.svg?style=svg)](https://circleci.com/gh/open-quantum-safe/openssh/tree/OQS-v8)
 
 OQS-OpenSSH
 ==================================

--- a/sshkey.c
+++ b/sshkey.c
@@ -515,8 +515,8 @@ sshkey_size(const struct sshkey *k)
 		return BN_num_bits(rsa_n) + k->oqs_pk_len;
 	CASE_KEY_ECDSA_HYBRID:
 		return sshkey_curve_nid_to_bits(k->ecdsa_nid) + k->oqs_pk_len;
-	}
 #endif /* WITH_OPENSSL */
+	}
 	return 0;
 }
 


### PR DESCRIPTION
- correct CCI icon to OQS-v8
- correct WITH_OPENSSL define

@xvzcf : Should build option "without OPENSSL" still function? One #define was placed incorrectly and `make tests LTESTS=""` now fails when setting `WITH_OPENSSL: false` in CCI config.yml.