### PR TITLE
Use mpint representation for shared_secret when deriving keys in pure-PQ key exchange, and some other bug fixes; fixes #119

### DIFF
--- a/kexoqs.c
+++ b/kexoqs.c
@@ -43,10 +43,12 @@ static int kex_kem_generic_keypair(OQS_KEM *kem, struct kex *kex)
   struct sshbuf *buf = NULL;
   u_char *cp = NULL;
   int r;
-  if ((buf = sshbuf_new()) == NULL)
+  if ((buf = sshbuf_new()) == NULL) {
     return SSH_ERR_ALLOC_FAIL;
-  if ((r = sshbuf_reserve(buf, kem->length_public_key, &cp)) != 0) \
+  }
+  if ((r = sshbuf_reserve(buf, kem->length_public_key, &cp)) != 0) {
     goto out;
+  }
   kex->oqs_client_key_size = kem->length_secret_key;
   if ((kex->oqs_client_key = malloc(kex->oqs_client_key_size)) == NULL ||
       OQS_KEM_keypair(kem, cp, kex->oqs_client_key) != OQS_SUCCESS) {
@@ -90,15 +92,17 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
     r = SSH_ERR_ALLOC_FAIL;
     goto out;
   }
-  if ((r = sshbuf_reserve(server_blob, kem->length_ciphertext, &ciphertext)) != 0)
+  if ((r = sshbuf_reserve(server_blob, kem->length_ciphertext, &ciphertext)) != 0) {
     goto out;
+  }
   /* generate and encrypt KEM key with client key */
   if (OQS_KEM_encaps(kem, ciphertext, kem_key, client_pub) != OQS_SUCCESS) {
     r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
-  if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0)
+  if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0) {
     goto out;
+  }
   *server_blobp = server_blob;
   *shared_secretp = buf;
   server_blob = NULL;
@@ -144,8 +148,9 @@ static int kex_kem_generic_dec(OQS_KEM *kem,
     r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
-  if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0)
+  if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0) {
     goto out;
+  }
   *shared_secretp = buf;
   buf = NULL;
  out:

--- a/kexoqs.c
+++ b/kexoqs.c
@@ -94,6 +94,7 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
     goto out;
   /* generate and encrypt KEM key with client key */
   if (OQS_KEM_encaps(kem, ciphertext, kem_key, client_pub) != OQS_SUCCESS) {
+    r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
   if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0)
@@ -140,6 +141,7 @@ static int kex_kem_generic_dec(OQS_KEM *kem,
     goto out;
   }
   if (OQS_KEM_decaps(kem, kem_key, ciphertext, kex->oqs_client_key) != OQS_SUCCESS) {
+    r = SSH_ERR_LIBCRYPTO_ERROR;
     goto out;
   }
   if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0)

--- a/kexoqs.c
+++ b/kexoqs.c
@@ -111,8 +111,8 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
   sshbuf_free(server_blob);
   sshbuf_free(buf);
   if (kem_key != NULL) {
-      explicit_bzero(kem_key, kem->length_shared_secret);
-      free(kem_key);
+    explicit_bzero(kem_key, kem->length_shared_secret);
+    free(kem_key);
   }
   return r;
 }
@@ -156,8 +156,8 @@ static int kex_kem_generic_dec(OQS_KEM *kem,
  out:
   sshbuf_free(buf);
   if (kem_key != NULL) {
-      explicit_bzero(kem_key, kem->length_shared_secret);
-      free(kem_key);
+    explicit_bzero(kem_key, kem->length_shared_secret);
+    free(kem_key);
   }
   return r;
 }

--- a/kexoqs.c
+++ b/kexoqs.c
@@ -68,7 +68,7 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
   struct sshbuf *server_blob = NULL;
   struct sshbuf *buf = NULL;
   const u_char *client_pub;
-  u_char *kem_key, *ciphertext;
+  u_char *kem_key = NULL, *ciphertext;
   int r;
   *server_blobp = NULL;
   *shared_secretp = NULL;
@@ -81,8 +81,10 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
     r = SSH_ERR_ALLOC_FAIL;
     goto out;
   }
-  if ((r = sshbuf_reserve(buf, kem->length_shared_secret, &kem_key)) != 0)
+  if ((kem_key = malloc(kem->length_shared_secret)) == NULL) {
+    r = SSH_ERR_ALLOC_FAIL;
     goto out;
+  }
   /* allocate space for encrypted KEM key */
   if ((server_blob = sshbuf_new()) == NULL) {
     r = SSH_ERR_ALLOC_FAIL;
@@ -94,6 +96,8 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
   if (OQS_KEM_encaps(kem, ciphertext, kem_key, client_pub) != OQS_SUCCESS) {
     goto out;
   }
+  if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0)
+    goto out;
   *server_blobp = server_blob;
   *shared_secretp = buf;
   server_blob = NULL;
@@ -101,6 +105,10 @@ static int kex_kem_generic_enc(OQS_KEM *kem, struct kex *kex,
  out:
   sshbuf_free(server_blob);
   sshbuf_free(buf);
+  if (kem_key != NULL) {
+      explicit_bzero(kem_key, kem->length_shared_secret);
+      free(kem_key);
+  }
   return r;
 }
 
@@ -127,15 +135,23 @@ static int kex_kem_generic_dec(OQS_KEM *kem,
     r = SSH_ERR_ALLOC_FAIL;
     goto out;
   }
-  if ((r = sshbuf_reserve(buf, kem->length_shared_secret, &kem_key)) != 0)
+  if ((kem_key = malloc(kem->length_shared_secret)) == NULL) {
+    r = SSH_ERR_ALLOC_FAIL;
     goto out;
+  }
   if (OQS_KEM_decaps(kem, kem_key, ciphertext, kex->oqs_client_key) != OQS_SUCCESS) {
     goto out;
   }
+  if ((r = sshbuf_put_string(buf, kem_key, kem->length_shared_secret)) != 0)
+    goto out;
   *shared_secretp = buf;
   buf = NULL;
  out:
   sshbuf_free(buf);
+  if (kem_key != NULL) {
+      explicit_bzero(kem_key, kem->length_shared_secret);
+      free(kem_key);
+  }
   return r;
 }
 

--- a/match.c
+++ b/match.c
@@ -265,7 +265,7 @@ match_user(const char *user, const char *host, const char *ipaddr,
  * Returns first item from client-list that is also supported by server-list,
  * caller must free the returned string.
  */
-#define	MAX_PROP	60
+#define	MAX_PROP	160
 #define	SEP	","
 char *
 match_list(const char *client, const char *server, u_int *next)

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -213,9 +213,11 @@ type_bits_valid(int type, const char *name, u_int32_t *bitsp)
 	   * by different types (unlike ECDSA which uses one key type and a 2nd
 	   * 'nid' value to identify the curve. We need this special processing
 	   * for ECDSA hybrid of levels 3+ to avoid defaulting to P256 when
-	   * name is NULL (like when called from do_gen_all_hostkeys).
+	   * name is NULL (like when called from do_gen_all_hostkeys) or when the
+	   * -t parameter is provided with a shortname, which sshkey_ecdsa_nid_from_name
+	   * doesn't check.
 	   */
-		if (name == NULL && oqs_utils_is_ecdsa_hybrid(type)) {
+		if (oqs_utils_is_ecdsa_hybrid(type)) {
 		  switch (type) {
 ///// OQS_TEMPLATE_FRAGMENT_HANDLE_ECDSA_HYBRIDS_START
 		  case KEY_ECDSA_NISTP521_FALCON_1024:


### PR DESCRIPTION
Other bug fixes:

1. Increase MAX_PROP to 160. Large numbers of proposals due to all the OQS algorithms can cause a non-spec-compliant selection of algorithm if this value is too low and client and server order their proposals differently. This had been fixed in v7 by #85 but returned in the v8 branch.
2. When calling `ssh-keygen` with the `-t` parameter to specify the key type for one of the ECDSA hybrids, but using the short name instead of the full `ssh-ecdsa-xxxxxxx` name, ECDSA keys would always be generated on P-256. Instead, always use the specified curve.
3. `kex_kem_generic_{enc,dec}` could use an uninitialized variable as the return value if the call to the underlying liboqs function failed. On the small chance that variable happened to have a zero in it, this would look like a successful result to teh caller. Return `SSH_ERR_LIBCRYPTO_ERROR` in these cases instead.