### PR TITLE
Remove mentions of Rainbow in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Note that algorithms marked with a dagger (†) have large stack usage and may c
 
 #### Digital Signature
 
-The following digital signature algorithms from liboqs are supported (assuming they have been enabled in liboqs). Note that only select L3 signature variants are enabled by default. In general, algorithms that are enabled by default are marked with an asterisk, and should you wish to enable additional variants, consult [the "Code Generation" section of the documentation in the wiki](https://github.com/open-quantum-safe/openssh/wiki/Using-liboqs-supported-algorithms-in-the-fork#code-generation). Note that enabling Rainbow will introduce a substantial execution delay to all operations. If doing it inadvertently, tests will fail and all kind of headaches occur. You have been warned.
+The following digital signature algorithms from liboqs are supported (assuming they have been enabled in liboqs). Note that only select L3 signature variants are enabled by default. In general, algorithms that are enabled by default are marked with an asterisk, and should you wish to enable additional variants, consult [the "Code Generation" section of the documentation in the wiki](https://github.com/open-quantum-safe/openssh/wiki/Using-liboqs-supported-algorithms-in-the-fork#code-generation).
 
 <!--- OQS_TEMPLATE_FRAGMENT_LIST_ALL_SIGS_START -->
 - **Dilithium**: `dilithium2`\*, `dilithium3`\*, `dilithium5`\*, `dilithium2aes`, `dilithium3aes`, `dilithium5aes`

--- a/oqs-test/try_connection.py
+++ b/oqs-test/try_connection.py
@@ -107,7 +107,7 @@ def do_handshake(ssh, sshd, test_sig, test_kex):
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
 
-    # sshd should locally (hopefully?) start within 1 second. If activating Rainbow, at least an order of magnitude more delay must be considered.
+    # sshd should locally (hopefully?) start within 1 second.
     time.sleep(1)
 
     # Try to connect to it with the client

--- a/packet.c
+++ b/packet.c
@@ -103,7 +103,7 @@
 #define DBG(x)
 #endif
 
-// OQS: Increasing for McEliece and Rainbow:
+// OQS: Increasing for McEliece:
 #define PACKET_MAX_SIZE (2500 * 1024)
 
 struct packet_state {


### PR DESCRIPTION
Removed mentions of Rainbow since it's no longer supported.