### PR TITLE
Update release documentation for OQS-OpenSSH snapshot 2024-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CircleCI](https://circleci.com/gh/open-quantum-safe/openssh/tree/OQS-v8.svg?style=svg)](https://circleci.com/gh/open-quantum-safe/openssh/tree/OQS-v8)
-
 OQS-OpenSSH
 ==================================
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ OQS-OpenSSH
 
 OQS-OpenSSH is a fork of OpenSSH that adds quantum-safe key exchange and signature algorithms using [liboqs](https://github.com/open-quantum-safe/liboqs) for prototyping and evaluation purposes. This fork is not endorsed by the OpenSSH project.
 
-THIS PROJECT IS PRESENTLY INACTIVE. CONTRIBUTORS WANTED.
-
 - [Overview](#overview)
 - [Status](#status)
   * [Limitations and Security](#limitations-and-security)
@@ -31,7 +29,7 @@ Both liboqs and this fork are part of the **Open Quantum Safe (OQS) project**, w
 
 ## Status
 
-This fork is currently based on OpenSSH version **8.9** (Git tag V_8_9_P1); release notes can be found [here](RELEASE.md). **IT IS AT AN EXPERIMENTAL STAGE**, and has not received the same level of auditing and analysis that OpenSSH has received. See the [Limitations and Security](#limitations-and-security) section below for more information.
+This fork is currently based on OpenSSH version **9.7** (Git tag V_9_7_P1); release notes can be found [here](RELEASE.md). **IT IS AT AN EXPERIMENTAL STAGE**, and has not received the same level of auditing and analysis that OpenSSH has received. See the [Limitations and Security](#limitations-and-security) section below for more information.
 
 **WE DO NOT RECOMMEND RELYING ON THIS FORK TO PROTECT SENSITIVE DATA.**
 
@@ -225,6 +223,7 @@ Contributors to this fork of OpenSSH include:
 - Douglas Stebila (University of Waterloo)
 - Goutam Tamvada (University of Waterloo)
 - Michael Baentsch
+- Gerardo Ravago (Amazon Web Services)
 
 Contributors to an earlier OQS fork of OpenSSH included:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-OQS-OpenSSH snapshot 2023-10
+OQS-OpenSSH snapshot 2024-08
 ============================
 
 About
@@ -13,20 +13,27 @@ The **Open Quantum Safe (OQS) project** has the goal of developing and prototypi
 Release notes
 =============
 
-This is the 2023-10 snapshot release of OQS-OpenSSH, released on October 21, 2023. This release is intended to be used with liboqs version 0.9.0.
+This is the 2024-08 snapshot release of OQS-OpenSSH, released on August 30, 2024. This release is intended to be used with liboqs version 0.10.1.
 
 What's New
 ----------
 
-This is the seventh snapshot release of the OQS fork of OpenSSH.  It is based on OpenSSH 8.9 portable 1.
+This is the eighth snapshot release of the OQS fork of OpenSSH.  It is based on OpenSSH 9.7 portable 1.
 
-- Update algorithm list in line with `liboqs` v0.9.0.
+- Updated fork to track upstream OpenSSH 9.7.
+- Update algorithm list in line with `liboqs` v0.10.1.
+  + Introduces generic support for ML-KEM, ML-DSA, SNTRUP, BIKEr4, MAYO, and Falcon (Padded).
+- Added support for x25519 hybrid key exchange algorithms.
+  + Working interop support for `x25519-kyber-512r3-sha256-d00@amazon.com` key exchange.
+  + Working interop support for `sntrup761x25519-sha512@openssh.com` key exchange.
+- Support for all ML-KEM based hybrid key exchanges in https://datatracker.ietf.org/doc/draft-kampanakis-curdle-ssh-pq-ke/
+  + `mlkem768nistp256-sha256`, `mlkem1024nistp384-sha384`, `mlkem768x25519-sha256`
+- Migrated from CircleCI to Github Actions.
 
 ---
 
 Detailed changelog
 ------------------
 
-* Update IDs to reflect updated McEliece in liboqs v0.9.0 in https://github.com/open-quantum-safe/openssh/pull/148
-
-**Full Changelog**: https://github.com/open-quantum-safe/openssh/compare/OQS-OpenSSH-snapshot-2023-06...OQS-OpenSSH-snapshot-2023-10
+**Full Changelog**: https://github.com/open-quantum-safe/openssh/compare/OQS-v8...b89166ed6ff4eb9af7cbc5dc5c82049ebda388df
+**Full Changelog (Omitting upstream merge): https://github.com/open-quantum-safe/openssh/compare/ac7c26b9e042fae7816eecaba9904e63bb706d12...b89166ed6ff4eb9af7cbc5dc5c82049ebda388df

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,7 @@ This is the eighth snapshot release of the OQS fork of OpenSSH.  It is based on 
   + Working interop support for `sntrup761x25519-sha512@openssh.com` key exchange.
 - Support for all ML-KEM based hybrid key exchanges in https://datatracker.ietf.org/doc/draft-kampanakis-curdle-ssh-pq-ke/
   + `mlkem768nistp256-sha256`, `mlkem1024nistp384-sha384`, `mlkem768x25519-sha256`
+  + For the `0.10.1` release of `liboqs`, these will be backed by the IPD versions of the algorithm.
 - Migrated from CircleCI to Github Actions.
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,8 @@ This is the eighth snapshot release of the OQS fork of OpenSSH.  It is based on 
 
 - Updated fork to track upstream OpenSSH 9.7.
 - Update algorithm list in line with `liboqs` v0.10.1.
-  + Introduces generic support for ML-KEM, ML-DSA, SNTRUP, BIKEr4, MAYO, and Falcon (Padded).
+  + Introduces generic support for ML-KEM-IPD, ML-DSA-IPD, SNTRUP, BIKEr4, MAYO, and Falcon (Padded).
+  + Support for ML-KEM and ML-DSA is provided using a `liboqs` alias which will update from the IPD versions to the final FIPS-203 and FIPS-204 standards when they are available in the underlying `liboqs`.
 - Added support for x25519 hybrid key exchange algorithms.
   + Working interop support for `x25519-kyber-512r3-sha256-d00@amazon.com` key exchange.
   + Working interop support for `sntrup761x25519-sha512@openssh.com` key exchange.

--- a/version.h
+++ b/version.h
@@ -1,6 +1,6 @@
 /* $OpenBSD: version.h,v 1.101 2024/03/11 04:59:47 djm Exp $ */
 
-#define SSH_VERSION	"OpenSSH_9.7-2022-01_"
+#define SSH_VERSION	"OpenSSH_9.7-2024-08_"
 
 #define SSH_PORTABLE	"p1"
-#define SSH_RELEASE	SSH_VERSION SSH_PORTABLE ", Open Quantum Safe 2022-08"
+#define SSH_RELEASE	SSH_VERSION SSH_PORTABLE ", Open Quantum Safe 2024-08"


### PR DESCRIPTION
Updates the files as described in the [wiki](https://github.com/open-quantum-safe/openssh/wiki/Release-process). After going through the release process myself, I'll update the wiki to fill in the blanks.