### PR TITLE
Update Base OpenSSH Version references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Both liboqs and this fork are part of the **Open Quantum Safe (OQS) project**, w
 
 ## Status
 
-This fork is currently based on OpenSSH version **9.7** (Git tag V_9_7_P1); release notes can be found [here](RELEASE.md). **IT IS AT AN EXPERIMENTAL STAGE**, and has not received the same level of auditing and analysis that OpenSSH has received. See the [Limitations and Security](#limitations-and-security) section below for more information.
+This fork is currently based on OpenSSH version **10.0** (Git tag V_10_0_P2); release notes can be found [here](RELEASE.md). **IT IS AT AN EXPERIMENTAL STAGE**, and has not received the same level of auditing and analysis that OpenSSH has received. See the [Limitations and Security](#limitations-and-security) section below for more information.
 
 **WE DO NOT RECOMMEND RELYING ON THIS FORK TO PROTECT SENSITIVE DATA.**
 


### PR DESCRIPTION
As a part of the uplift to OpenSSH V_10_0_P2 done in #181, the references to what OpenSSH version the project is based on needs to be updated as well. 