### PR TITLE
Add security fixes

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -719,6 +719,26 @@ kex_free_newkeys(struct newkeys *newkeys)
 }
 
 void
+kex_reset_keys(struct kex *kex) {
+#ifdef OPENSSL_HAS_ECC
+	EC_KEY_free(kex->ec_client_key);
+	kex->ec_client_key = NULL;
+	kex->ec_group = NULL;
+#endif
+	if (kex->oqs_client_key != NULL)
+		freezero(kex->oqs_client_key, kex->oqs_client_key_size);
+	kex->oqs_client_key = NULL;
+	kex->oqs_client_key_size = 0;
+#ifndef USE_ECDH_X25519
+	explicit_bzero(kex->c25519_client_key, sizeof(kex->c25519_client_key));
+#endif
+	explicit_bzero(kex->sntrup761_client_key,
+	    sizeof(kex->sntrup761_client_key));
+	explicit_bzero(kex->mlkem768_client_key,
+	    sizeof(kex->mlkem768_client_key));
+}
+
+void
 kex_free(struct kex *kex)
 {
 	u_int mode;
@@ -728,10 +748,8 @@ kex_free(struct kex *kex)
 
 #ifdef WITH_OPENSSL
 	DH_free(kex->dh);
-#ifdef OPENSSL_HAS_ECC
-	EC_KEY_free(kex->ec_client_key);
-#endif /* OPENSSL_HAS_ECC */
 #endif /* WITH_OPENSSL */
+	kex_reset_keys(kex);
 	for (mode = 0; mode < MODE_MAX; mode++) {
 		kex_free_newkeys(kex->newkeys[mode]);
 		kex->newkeys[mode] = NULL;
@@ -748,10 +766,6 @@ kex_free(struct kex *kex)
 	free(kex->hostkey_alg);
 	free(kex->name);
 	free(kex->server_sig_algs);
-	if (kex->oqs_client_key) {
-	  free(kex->oqs_client_key);
-	  kex->oqs_client_key = NULL;
-	}
 	free(kex);
 }
 

--- a/kexgen.c
+++ b/kexgen.c
@@ -606,6 +606,7 @@ input_kex_gen_reply(int type, uint32_t seq, struct ssh *ssh)
 	/* success */
 out:
 	explicit_bzero(hash, sizeof(hash));
+	kex_reset_keys(kex);
 	explicit_bzero(kex->c25519_client_key, sizeof(kex->c25519_client_key));
 	explicit_bzero(kex->sntrup761_client_key,
 	    sizeof(kex->sntrup761_client_key));

--- a/ssh-oqs.c
+++ b/ssh-oqs.c
@@ -159,6 +159,7 @@ static void ssh_generic_cleanup(struct sshkey *k)
   if ((classical != NULL) && (classical->funcs->cleanup != NULL)) {
     classical->funcs->cleanup(k);
   }
+  sshkey_clear_pkey(k);
   return;
 }
 
@@ -559,6 +560,7 @@ out:
   sshbuf_free(b);
   sshbuf_free(algname_expected);
   free(algname_expected_str);
+  free(algname);
   return r;
 }
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -854,6 +854,13 @@ sshkey_free(struct sshkey *k)
 	freezero(k, sizeof(*k));
 }
 
+/* Frees EVP_PKEY pkey field */
+void
+sshkey_clear_pkey(struct sshkey *k) {
+	EVP_PKEY_free(k->pkey);
+	k->pkey = NULL;
+}
+
 static int
 cert_compare(struct sshkey_cert *a, struct sshkey_cert *b)
 {

--- a/sshkey.h
+++ b/sshkey.h
@@ -359,6 +359,7 @@ int	sshkey_serialize_private_sk(const struct sshkey *key,
     struct sshbuf *buf);
 int	sshkey_private_deserialize_sk(struct sshbuf *buf, struct sshkey *k);
 #ifdef WITH_OPENSSL
+void	sshkey_clear_pkey(struct sshkey *k);
 int	check_rsa_length(const RSA *rsa); /* XXX remove */
 #endif
 #endif


### PR DESCRIPTION
This PR proposes a pair of security enhancements found during an internal security audit. The commits respectively contain:
- fix MLDSA cleanup leaks by releasing EVP_PKEY state and algname on cleanup paths. Add in a `sshkey_clear_pkey` function to handle this.
- Fix client KEX private material retention by clearing KEX private fields after exchange completion. Add in a `kex_reset_keys` function to handle this.